### PR TITLE
Improve data fetching and clarify inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,26 +65,26 @@
         </div>
         <div>
           <label for="annFee">Annual Expense Ratio</label>
-          <input id="annFee" type="number" step="0.0001" value="0.0091" />
-          <div class="note">Annual (e.g., <code>0.0091</code> for 0.91%). Converted to a daily fee with 252 trading days.</div>
+          <input id="annFee" type="number" step="0.0001" value="0.0091" placeholder="e.g., 0.0091" />
+          <div class="note">Annual ratio in decimal (e.g., <code>0.0091</code>) converted to daily using 252 trading days.</div>
         </div>
         <div>
           <label for="drag">Extra Daily Drag</label>
-          <input id="drag" type="number" step="0.00001" placeholder="e.g., 0.00005 (~1.26%/yr) to 0.00020 (~5%/yr)" />
-          <div class="note">Optional: financing/rebalancing/inefficiency beyond the expense ratio.</div>
+          <input id="drag" type="number" step="0.00001" placeholder="e.g., 0.00005" />
+          <div class="note">Optional daily extra drag, e.g., 0.00005–0.00020.</div>
         </div>
         <div>
           <label for="endDate">Metrics End Date (optional)</label>
-          <input id="endDate" type="date" />
-          <div class="note">Trailing windows end here; blank = last available date.</div>
+          <input id="endDate" type="date" placeholder="YYYY-MM-DD" />
+          <div class="note">Trailing windows end here; leave blank for latest date.</div>
         </div>
       </div>
 
       <div class="row">
         <div>
           <label for="corsProxy">CORS Proxy (optional)</label>
-          <input id="corsProxy" placeholder="e.g., https://cors.isomorphic-git.org/" />
-          <div class="note">If your browser blocks direct fetch from Stooq, add a proxy. Try blank first.</div>
+          <input id="corsProxy" placeholder="https://cors.isomorphic-git.org/" />
+          <div class="note">Use a CORS proxy if needed; leave blank to use the default.</div>
         </div>
         <div class="center">
           <button id="runBtn" class="primary">Fetch &amp; Compute</button>
@@ -181,17 +181,18 @@ function stooqUrlFromSymbol(sym) {
 }
 
 async function fetchCsv(url) {
-  try {
-    const res = await fetch(url);
+  async function get(u) {
+    const res = await fetch(u);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.text();
+    return res.text();
+  }
+  try {
+    return await get(url);
   } catch (e) {
-    const proxy = corsProxy.value.trim();
-    if (!proxy) throw e;
+    const userProxy = corsProxy.value.trim();
+    const proxy = userProxy || "https://cors.isomorphic-git.org/";
     const proxied = proxy.endsWith("/") ? proxy + url : proxy + "/" + url;
-    const res2 = await fetch(proxied);
-    if (!res2.ok) throw new Error(`Proxy HTTP ${res2.status}`);
-    return await res2.text();
+    return await get(proxied);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add default CORS proxy fallback to ensure data fetching works even when direct Stooq requests fail.
- Provide example placeholders and concise one-line descriptions for input fields like annual fee, daily drag, end date, and CORS proxy.

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a74668dbd88322aef99b603d62b25b