### PR TITLE
Handle Alpha Vantage daily CSV

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,8 @@ function computeSeries(data, leverage, annualExpense, extraDrag) {
     const rows = text.trim().split(/\r?\n/).map(line => line.split(","));
     const header = rows.shift();
     const idxDate = header.indexOf("timestamp");
-    const idxClose = header.indexOf("adjusted_close");
+    let idxClose = header.indexOf("adjusted_close");
+    if (idxClose === -1) idxClose = header.indexOf("close");
     if (idxDate === -1 || idxClose === -1) throw new Error("Unexpected CSV columns from Alpha Vantage.");
     return rows.map(cols => ({
       date: cols[idxDate],
@@ -404,7 +405,7 @@ runBtn.addEventListener("click", async () => {
       if (source === "alphavantage") {
         const key = apiKey.value.trim();
         if (!key) throw new Error("Enter API key for Alpha Vantage.");
-        const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY_ADJUSTED&symbol=${encodeURIComponent(sym)}&apikey=${key}&outputsize=full&datatype=csv`;
+        const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=${encodeURIComponent(sym)}&apikey=${key}&outputsize=full&datatype=csv`;
         csv = await fetchCsv(url);
         raw = parseAlphaVantageCsv(csv).sort((a,b) => a.date.localeCompare(b.date));
         if (raw.length < 2) throw new Error("Insufficient rows from Alpha Vantage.");


### PR DESCRIPTION
## Summary
- allow Alpha Vantage CSV parser to use `close` column when `adjusted_close` is missing
- switch Alpha Vantage requests to the free `TIME_SERIES_DAILY` endpoint

## Testing
- `curl -L 'https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=IBM&apikey=3CYLUDBDF6S85HFR&datatype=csv' | head`
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a1291f88832292618fd243dfc9aa